### PR TITLE
Fix and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ A React app for the BYRDMR drone, with two views (and corresponding components):
 ## How to test locally:
 
 In the project directory, run `npm run test` in Terminal.  
+Tests are found in the folder `src/components/__tests__`.
+I've also mocked axios in the folder `src/__mocks__`, and subsequently used this to test the function `postMessage`.
 
 This launches the test runner in the interactive watch mode.\
 See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.  
@@ -123,7 +125,7 @@ describe('The DropdownMenu', () => {
 ```
 
 ### Next-steps / improvements:
-* Lots more testing could be done, including unit tests and component tests, and testing the axios post request
+* Lots more testing could be done, including unit tests and component tests.
 * Error handling in `Contact` can be improved (also potentially to display a message to the user if there has been a problem with form submission)
 * Further tweaks to styling; e.g. see 'Other comments' section in this pull request: https://github.com/Simon994/brydmr/pull/1
 * Add social media icons in `Contact` to match the Sketch

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ In the project directory, run `npm run test` in Terminal.
 This launches the test runner in the interactive watch mode.\
 See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.  
 
-Please note that although (snapshot) tests have been written, these are currently failing: see below in the 'Testing' section for details of why.
 
 ## Other scripts
 
@@ -107,26 +106,23 @@ App.js currently contains `Route`s for the `Hero` and `Contact` components. More
 
 ### Testing
 Some (crude!) tests have been added for the Hero component and children (in the folder `components/__tests__/`). 
-These are simple snapshot tests using Jest. For example, to test that the dropdown renders:
+These are simple snapshot tests using Jest. For example, to test that the dropdown renders as expected:
 
 ```JavaScript
 describe('The DropdownMenu', () => {
   it('renders as expected', () => {
-    const tree = renderer.create(<DropdownMenu/>).toJSON()
+    const tree = renderer.create(
+      <BrowserRouter>
+        <DropdownMenu/>
+      </BrowserRouter>
+      ).toJSON()
 
     expect(tree).toMatchSnapshot()
   })
 })
 ```
-As it stands, the tests are currently failing. This is because, in the `MenuAndNavItems` component, we use `NavLink` (imported from react-router-dom node module) to link the list items to other views. Jest currently fails tests with the message: Invariant failed: You should not use `<withRouter(MenuAndNavItems) />` outside a `<Router>`.  
-
-Without using `NavLink` (or by adding `Router` around `NavLink`), the tests pass, but this would then seemingly mean that we won't have appropriate routing in the component.
-
-The test(s) will need to be updated to account for the above — I’m going to look into this further for future!
-
 
 ### Next-steps / improvements:
-* Update tests (or possibly the `MenuAndNavItems` component itself) to fix the problem described above, which is currently leading to failing tests
 * Lots more testing could be done, including unit tests and component tests, and testing the axios post request
 * Error handling in `Contact` can be improved (also potentially to display a message to the user if there has been a problem with form submission)
 * Further tweaks to styling; e.g. see 'Other comments' section in this pull request: https://github.com/Simon994/brydmr/pull/1

--- a/src/__mocks__/axios.js
+++ b/src/__mocks__/axios.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import/no-anonymous-default-export
+export default {
+  post: jest.fn(() => Promise.resolve({ data: {} }))
+  }

--- a/src/components/__tests__/Contact.js
+++ b/src/components/__tests__/Contact.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { BrowserRouter } from 'react-router-dom'
+import renderer from 'react-test-renderer'
+import Contact from '../Contact'
+
+describe('The Contact component', () => {
+  it('renders as expected', () => {
+    const tree = renderer.create(
+      <BrowserRouter>
+        <Contact/>
+      </BrowserRouter>
+      ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/components/__tests__/DropdownMenu.js
+++ b/src/components/__tests__/DropdownMenu.js
@@ -1,10 +1,15 @@
 import React from 'react'
+import { BrowserRouter } from 'react-router-dom'
 import renderer from 'react-test-renderer'
 import DropdownMenu from '../common/DropdownMenu'
 
 describe('The DropdownMenu', () => {
   it('renders as expected', () => {
-    const tree = renderer.create(<DropdownMenu/>).toJSON()
+    const tree = renderer.create(
+      <BrowserRouter>
+        <DropdownMenu/>
+      </BrowserRouter>
+      ).toJSON()
 
     expect(tree).toMatchSnapshot()
   })

--- a/src/components/__tests__/Hero.js
+++ b/src/components/__tests__/Hero.js
@@ -1,10 +1,15 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import Hero from '../Hero'
+import { BrowserRouter } from "react-router-dom";
 
 describe('The Hero component', () => {
   it('renders as expected', () => {
-    const tree = renderer.create(<Hero/>).toJSON()
+    const tree = renderer.create(
+      <BrowserRouter>
+            <Hero/>
+      </BrowserRouter>)
+      .toJSON()
 
     expect(tree).toMatchSnapshot()
   })

--- a/src/components/__tests__/HeroDesktopNavbar.js
+++ b/src/components/__tests__/HeroDesktopNavbar.js
@@ -1,10 +1,15 @@
 import React from 'react'
+import { BrowserRouter } from 'react-router-dom'
 import renderer from 'react-test-renderer'
 import HeroDesktopNavbar from '../HeroDesktopNavbar'
 
 describe('The HeroDesktopNavbar (navbar for hero view on desktop device)', () => {
   it('renders as expected', () => {
-    const tree = renderer.create(<HeroDesktopNavbar/>).toJSON()
+    const tree = renderer.create(
+      <BrowserRouter>
+        <HeroDesktopNavbar/>
+      </BrowserRouter>
+    ).toJSON()
 
     expect(tree).toMatchSnapshot()
   })

--- a/src/components/__tests__/__snapshots__/Contact.js.snap
+++ b/src/components/__tests__/__snapshots__/Contact.js.snap
@@ -1,0 +1,134 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The Contact component renders as expected 1`] = `
+<div
+  className="contact-container"
+>
+  <div
+    className="outer-menu-container"
+  >
+    <img
+      alt="ByrdMR logo"
+      className="byrd-logo"
+      src="Logo.png"
+    />
+    <div
+      className="inner-menu-container"
+    >
+      <button
+        className="menu-trigger"
+        onClick={[Function]}
+      >
+        <img
+          alt="Menu button icon"
+          src="menu.png"
+        />
+      </button>
+      <nav
+        className="menu inactive"
+      >
+        <ul>
+          <li>
+            <a
+              aria-current={null}
+              className="nav-link"
+              href="/store"
+              onClick={[Function]}
+            >
+              STORE
+            </a>
+          </li>
+          <li>
+            <a
+              aria-current={null}
+              className="nav-link"
+              href="/tutorials"
+              onClick={[Function]}
+            >
+              TUTORIALS
+            </a>
+          </li>
+        </ul>
+        <ul>
+          <li>
+            <a
+              aria-current={null}
+              className="nav-link"
+              href="/blog"
+              onClick={[Function]}
+            >
+              BLOG
+            </a>
+          </li>
+          <li>
+            <a
+              aria-current={null}
+              className="nav-link"
+              href="/contact"
+              onClick={[Function]}
+            >
+              CONTACT
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+  <div
+    className="form-container"
+  >
+    <form
+      onSubmit={[Function]}
+    >
+      <label
+        className="form-label"
+      >
+        FULL NAME
+      </label>
+      <input
+        className="input-regular"
+        name="fullName"
+        onChange={[Function]}
+        placeholder="Enter your full name"
+        value=""
+      />
+      <label
+        className="form-label"
+      >
+        EMAIL
+      </label>
+      <input
+        className="input-regular"
+        name="email"
+        onChange={[Function]}
+        placeholder="Enter your email"
+        value=""
+      />
+      <label
+        className="form-label"
+      >
+        MESSAGE
+      </label>
+      <textarea
+        className="input-large"
+        name="message"
+        onChange={[Function]}
+        placeholder="What are your plans?"
+        value=""
+      />
+      <button
+        type="submit"
+      >
+        <div>
+          Send Message
+        </div>
+        <div
+          id="arrow"
+        >
+          →
+        </div>
+      </button>
+    </form>
+  </div>
+</div>
+`;

--- a/src/components/__tests__/postMessage.js
+++ b/src/components/__tests__/postMessage.js
@@ -1,0 +1,36 @@
+import mockAxios from 'axios';
+
+import { postMessage } from '../../lib/api'
+
+describe('postMessage', () => {
+  it('successfully posts the message to axios', async () => {
+    // setup
+    const dataFromMock = {
+      fullName: 'beans',
+      email: 'beans@email.com',
+      message: 'Hi, I am some beans'
+    }
+    mockAxios.post.mockImplementationOnce(() =>
+      Promise.resolve({
+        data: dataFromMock
+      })
+    )
+
+    // work
+    const formDataToSend = {
+      fullName: 'beans',
+      email: 'beans@email.com',
+      message: 'Hi, I am some beans'
+    }
+  
+    const response = await postMessage(formDataToSend)
+    
+    // expect
+    expect(response.data).toEqual(dataFromMock)
+    expect(mockAxios.post).toHaveBeenCalledTimes(1);
+    expect(mockAxios.post).toHaveBeenCalledWith(
+      '/api/messages/',
+      formDataToSend
+    )
+  })
+})


### PR DESCRIPTION
## What's been done:
* Fix snapshot tests by including BrowserRouter
* Add snapshot test for Contact component
* Add test for postMessage (including using mocked axios)
* All tests now passing
* Update README to reflect changes

## How to run locally:
Clone or download the repo
Install dependencies: run `npm i` in Terminal
Start the development server: run `npm start`
Navigate in your browser to localhost:3000 You should see the frontend being served to the browser.

## How to test locally:
run `npm run test` in Terminal.